### PR TITLE
Update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,27 @@
-FROM python:2-wheezy
+FROM ubuntu:20.04
 
 WORKDIR /root
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y git-core wget build-essential liblzma-dev liblzo2-dev zlib1g-dev unrar-free && \
-    pip install -U pip
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y \
+      build-essential \
+      git-core \
+      liblzma-dev \
+      liblzo2-dev \
+      python3-pip \
+      unrar-free \
+      wget \
+      zlib1g-dev && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 10 # python should be py3
 
-RUN git clone https://github.com/firmadyne/sasquatch && \
-    cd sasquatch && \
-    make && \
-    make install && \
-    cd .. && \
-    rm -rf sasquatch
-
-RUN git clone https://github.com/devttys0/binwalk.git && \
-    cd binwalk && \
+RUN git clone -q --depth=1 https://github.com/devttys0/binwalk.git /root/binwalk && \
+    cd /root/binwalk && \
     ./deps.sh --yes && \
-    python setup.py install && \
-    pip install 'git+https://github.com/ahupp/python-magic' && \
-    pip install 'git+https://github.com/sviehb/jefferson' && \
-    cd .. && \
-    rm -rf binwalk
+    python3 ./setup.py install && \
+    pip3 install git+https://github.com/ahupp/python-magic && \
+    pip3 install git+https://github.com/sviehb/jefferson && \
+    pip3 install pylzma # jefferson dependency, needs build-essential
 
-RUN \
-  adduser --disabled-password \
-          --gecos '' \
-          --home /home/extractor \
-          extractor
-
-USER extractor
-WORKDIR /home/extractor
-
-RUN git clone https://github.com/firmadyne/extractor.git
+COPY extractor.py /root/
+WORKDIR /root/


### PR DESCRIPTION
Prior to this PR, the docker container would fail to build because the sources were outdated (error below). This switches the container to be FROM ubuntu:20.04 and makes a few other changes to get it working.

Note that setting python to mean python3 in the container was necessary to get binwalk's deps.sh to work correctly.

It also changes the container to just use the `root` user as extraction will be more accurate (i.e., permissions will be maintained) when run as root.

Here's the error message that you'd get from trying to build the container before this PR:
```
Step 3/9 : RUN apt-get update &&     apt-get upgrade -y &&     apt-get install -y git-core wget build-essential liblzma-dev liblzo2-dev zlib1g-dev unrar-free &&     pip install -U pip
 ---> Running in d259e3fc8d91
Ign http://security.debian.org wheezy/updates Release.gpg
Ign http://security.debian.org wheezy/updates Release
Ign http://deb.debian.org wheezy Release.gpg
Err http://security.debian.org wheezy/updates/main amd64 Packages

Err http://security.debian.org wheezy/updates/main amd64 Packages

Ign http://deb.debian.org wheezy-updates Release.gpg
Err http://security.debian.org wheezy/updates/main amd64 Packages

Err http://security.debian.org wheezy/updates/main amd64 Packages

Ign http://deb.debian.org wheezy Release
Err http://security.debian.org wheezy/updates/main amd64 Packages
  404  Not Found [IP: 151.101.194.132 80]
Ign http://deb.debian.org wheezy-updates Release
Err http://deb.debian.org wheezy/main amd64 Packages
  404  Not Found
Err http://deb.debian.org wheezy-updates/main amd64 Packages
  404  Not Found
W: Failed to fetch http://security.debian.org/debian-security/dists/wheezy/updates/main/binary-amd64/Packages  404  Not Found [IP: 151.101.194.132 80]

W: Failed to fetch http://deb.debian.org/debian/dists/wheezy/main/binary-amd64/Packages  404  Not Found

W: Failed to fetch http://deb.debian.org/debian/dists/wheezy-updates/main/binary-amd64/Packages  404  Not Found

E: Some index files failed to download. They have been ignored, or old ones used instead.
The command '/bin/sh -c apt-get update &&     apt-get upgrade -y &&     apt-get install -y git-core wget build-essential liblzma-dev liblzo2-dev zlib1g-dev unrar-free &&     pip install -U pip' returned a non-zero code: 100
```